### PR TITLE
Use nearest_smpte_timecode_rate instead of trusting 23.98, etc.

### DIFF
--- a/src/otio_ale_adapter/ale.py
+++ b/src/otio_ale_adapter/ale.py
@@ -221,7 +221,8 @@ def read_from_string(input_str, fps=24, **adapter_argument_map):
                     raise ALEParseError("Invalid Heading line: " + line)
 
         if "FPS" in header:
-            fps = float(header["FPS"])
+            read_fps = float(header["FPS"])
+            fps = otio.opentime.RationalTime.nearest_smpte_timecode_rate(read_fps)
 
         if line.strip() == "Column":
             if len(lines) == 0:

--- a/tests/test_ale_adapter.py
+++ b/tests/test_ale_adapter.py
@@ -60,6 +60,7 @@ class ALEAdapterTest(unittest.TestCase):
         self.assertEqual(len(collection), 2)
         fps = float(collection.metadata.get("ALE").get("header").get("FPS"))
         self.assertEqual(fps, 23.98)
+        real_fps = otio.opentime.RationalTime.nearest_smpte_timecode_rate(fps)
         self.assertEqual(
             [c.name for c in collection],
             ["19A-1xa", "19A-2xa"]
@@ -68,12 +69,12 @@ class ALEAdapterTest(unittest.TestCase):
             [c.source_range for c in collection],
             [
                 otio.opentime.TimeRange(
-                    otio.opentime.from_timecode("04:00:00:00", fps),
-                    otio.opentime.from_timecode("00:00:46:16", fps)
+                    otio.opentime.from_timecode("04:00:00:00", real_fps),
+                    otio.opentime.from_timecode("00:00:46:16", real_fps)
                 ),
                 otio.opentime.TimeRange(
-                    otio.opentime.from_timecode("04:00:46:16", fps),
-                    otio.opentime.from_timecode("00:00:50:16", fps)
+                    otio.opentime.from_timecode("04:00:46:16", real_fps),
+                    otio.opentime.from_timecode("00:00:50:16", real_fps)
                 )
             ]
         )
@@ -86,6 +87,7 @@ class ALEAdapterTest(unittest.TestCase):
         self.assertEqual(len(collection), 4)
         fps = float(collection.metadata.get("ALE").get("header").get("FPS"))
         self.assertEqual(fps, 23.976)
+        real_fps = otio.opentime.RationalTime.nearest_smpte_timecode_rate(fps)
         self.assertEqual([c.name for c in collection], [
             "A005_C010_0501J0", "A005_C010_0501J0", "A005_C009_0501A0",
             "A005_C010_0501J0"
@@ -93,20 +95,20 @@ class ALEAdapterTest(unittest.TestCase):
         self.assertEqual([c.source_range for c in collection], [
 
             otio.opentime.TimeRange(
-                otio.opentime.from_timecode("17:49:33:01", fps),
-                otio.opentime.from_timecode("00:00:02:09", fps)),
+                otio.opentime.from_timecode("17:49:33:01", real_fps),
+                otio.opentime.from_timecode("00:00:02:09", real_fps)),
 
             otio.opentime.TimeRange(
-                otio.opentime.from_timecode("17:49:55:19", fps),
-                otio.opentime.from_timecode("00:00:06:09", fps)),
+                otio.opentime.from_timecode("17:49:55:19", real_fps),
+                otio.opentime.from_timecode("00:00:06:09", real_fps)),
 
             otio.opentime.TimeRange(
-                otio.opentime.from_timecode("17:40:25:06", fps),
-                otio.opentime.from_timecode("00:00:02:20", fps)),
+                otio.opentime.from_timecode("17:40:25:06", real_fps),
+                otio.opentime.from_timecode("00:00:02:20", real_fps)),
 
             otio.opentime.TimeRange(
-                otio.opentime.from_timecode("17:50:21:23", fps),
-                otio.opentime.from_timecode("00:00:03:14", fps))
+                otio.opentime.from_timecode("17:50:21:23", real_fps),
+                otio.opentime.from_timecode("00:00:03:14", real_fps))
         ])
 
         # Slope, offset, and power values are of type _otio.AnyVector
@@ -164,22 +166,19 @@ class ALEAdapterTest(unittest.TestCase):
     def test_ale_uhd(self):
         ale_path = EXAMPLEUHD_PATH
         collection = otio.adapters.read_from_file(ale_path)
-        frmt = str(
-            collection.metadata.get("ALE").get("header").get("VIDEO_FORMAT")
-        )
+        frmt = str(collection.metadata.get("ALE").get("header").get("VIDEO_FORMAT"))
         self.assertEqual(frmt, "CUSTOM")
 
     def test_ale_add_format(self):
 
         # adds a clip to the supplied timeline, sets the clips "Image Size"
-        # metadata and then rountrips the ALE verifying the supplied format
-        # is detected
+        # metadata and then rountrips the ALE verifying the supplied format is detected
         def add_then_check(timeline, size, expected_format):
             cl = otio.schema.Clip(
                 metadata={'ALE': {'Image Size': size}},
                 source_range=otio.opentime.TimeRange(
-                    start_time=otio.opentime.RationalTime(0, 23.976),
-                    duration=otio.opentime.RationalTime(48, 23.976)
+                    start_time=otio.opentime.RationalTime(0, 24000 / 1001),
+                    duration=otio.opentime.RationalTime(48, 24000 / 1001)
                 )
             )
             timeline.tracks[0].extend([cl])


### PR DESCRIPTION
This PR takes advantage of the new `nearest_smpte_timecode_rate` function added in this OTIO PR: https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/1477 to ensure that proper fractional rates like 24000/1001 and 30000/1001 are used when reading an ALE instead of common practice truncated or rounded rates like 23.98 or 29.97.

This PR should not be landed until the PR linked above is landed.