### PR TITLE
Limit 1.0.x release to OTIO <0.18.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         # Use macos-13 so we'll be on intel hardware and can pull a pre-built wheel
         # When OTIO has an Apple Silicon build we can switch back to macos-latest for that version
-        os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        otio-version: ["0.17.0", "main"]
+        os: [ubuntu-latest, windows-latest, macos-14, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        otio-version: ["0.17"]
 
     runs-on: ${{ matrix.os }}
 
@@ -40,7 +40,7 @@ jobs:
           if [[ "${{ matrix.otio-version }}" == "main" ]]; then
             pip install "git+https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git"
           else
-            pip install OpenTimelineIO>=${{ matrix.otio-version }} --only-binary :all:
+            pip install OpenTimelineIO=="${{ matrix.otio-version }}" --only-binary :all:
           fi
           pip install flake8 pytest pytest-cov
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "otio-ale-adapter"
-version = "1.1.0"
+version = "1.0.1"
 description = "OpenTimelineIO ALE Adapter"
 authors = [
   { name="Contributors to the OpenTimelineIO project", email="otio-discussion@lists.aswf.io" },
@@ -15,7 +15,7 @@ license = { file="LICENSE" }
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    "opentimelineio >= 0.17.0"
+    "opentimelineio >= 0.15.0, <0.18.0"
 ]
 
 classifiers = [


### PR DESCRIPTION
Change version number to 1.0.1

Without limiting to below 18:

```
$> pip install -e .
Obtaining ./otio-ale-adapter
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Installing backend dependencies ... done
  Preparing editable metadata (pyproject.toml) ... done
Collecting opentimelineio>=0.15.0 (from otio-ale-adapter==1.1.0)
  Using cached opentimelineio-0.18.1-cp314-cp314-macosx_10_15_x86_64.whl
Building wheels for collected packages: otio-ale-adapter
  Building editable for otio-ale-adapter (pyproject.toml) ... done
  Created wheel for otio-ale-adapter: filename=otio_ale_adapter-1.1.0-py3-none-any.whl size=10848 sha256=4705fe85c987feba3a48c464919335962cb4a24ca8654a892c744a2d21ae026a
  Stored in directory: /private/var/folders/0w/r31502yj1_n2wdh1_p68wphw0000gn/T/pip-ephem-wheel-cache-5cvepr0j/wheels/25/90/ac/d5097b7be7a13ac9b51f687120f267688ab36c880b282c2350
Successfully built otio-ale-adapter
Installing collected packages: opentimelineio, otio-ale-adapter
Successfully installed opentimelineio-0.18.1 otio-ale-adapter-1.1.0
```

Which will break many ALE files

With limiting to below 18:

```
$> pip install -e .
Obtaining file:///Users/sean/Projects/cdl_convert/otio-ale-adapter
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Installing backend dependencies ... done
  Preparing editable metadata (pyproject.toml) ... done
Collecting opentimelineio<0.18.0,>=0.15.0 (from otio-ale-adapter==1.1.0)
  Using cached opentimelineio-0.17.0-cp314-cp314-macosx_13_0_x86_64.whl
Building wheels for collected packages: otio-ale-adapter
  Building editable for otio-ale-adapter (pyproject.toml) ... done
  Created wheel for otio-ale-adapter: filename=otio_ale_adapter-1.1.0-py3-none-any.whl size=10856 sha256=cd6ee35e43a37bd5406c625116dc1ccd4c4ab5379bc439bd01f1c5dd1ad2e438
  Stored in directory: /private/var/folders/0w/r31502yj1_n2wdh1_p68wphw0000gn/T/pip-ephem-wheel-cache-af2oif8_/wheels/25/90/ac/d5097b7be7a13ac9b51f687120f267688ab36c880b282c2350
Successfully built otio-ale-adapter
Installing collected packages: opentimelineio, otio-ale-adapter
Successfully installed opentimelineio-0.17.0 otio-ale-adapter-1.1.0
```